### PR TITLE
Adiciona entidade Order e configurações no modelo de dados

### DIFF
--- a/DatabaseContext/Config/OrderConfig.cs
+++ b/DatabaseContext/Config/OrderConfig.cs
@@ -1,0 +1,46 @@
+﻿using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DatabaseContext.Config
+{
+    public class OrderConfig : IEntityTypeConfiguration<Order>
+    {
+        public void Configure(EntityTypeBuilder<Order> builder)
+        {
+            builder.ToTable("Orders");
+            builder.HasKey(order => order.OrderId);
+
+            builder.Property(order => order.Market)
+                .HasColumnType("varchar")
+                .HasMaxLength(Order.MAX_MARKET_LENGTH)
+                .IsRequired();
+
+            builder.Property(order => order.Side)
+                .HasColumnType("varchar")
+                .HasMaxLength(Order.MAX_SIDE_LENGTH)
+                .IsRequired();
+
+            builder.Property(order => order.Quantity)
+                .IsRequired();
+
+            builder.Property(order => order.Price)
+                .HasColumnType("decimal(19,4)");
+
+            builder.Property(order => order.FillQuantity)
+                .IsRequired();
+
+            builder.Property(order => order.FillPrice)
+                .HasColumnType("decimal(19,4)");
+
+            builder.Property(order => order.CreatedAt)
+                .IsRequired();
+
+            builder
+                .HasOne(order => order.Account)
+                .WithMany(account => account.Orders)
+                .HasForeignKey(order => order.AccountId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/DatabaseContext/Migrations/20250512150741_CreateTableOrder.Designer.cs
+++ b/DatabaseContext/Migrations/20250512150741_CreateTableOrder.Designer.cs
@@ -4,6 +4,7 @@ using DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DatabaseContext.Migrations
 {
     [DbContext(typeof(TradezillaContext))]
-    partial class TradezillaContextModelSnapshot : ModelSnapshot
+    [Migration("20250512150741_CreateTableOrder")]
+    partial class CreateTableOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DatabaseContext/Migrations/20250512150741_CreateTableOrder.cs
+++ b/DatabaseContext/Migrations/20250512150741_CreateTableOrder.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DatabaseContext.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateTableOrder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    OrderId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AccountId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Market = table.Column<string>(type: "varchar(7)", maxLength: 7, nullable: false),
+                    Side = table.Column<string>(type: "varchar(5)", maxLength: 5, nullable: false),
+                    Quantity = table.Column<int>(type: "int", nullable: false),
+                    Price = table.Column<decimal>(type: "decimal(19,4)", nullable: false),
+                    FillQuantity = table.Column<int>(type: "int", nullable: false),
+                    FillPrice = table.Column<decimal>(type: "decimal(19,4)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.OrderId);
+                    table.ForeignKey(
+                        name: "FK_Orders_Accounts_AccountId",
+                        column: x => x.AccountId,
+                        principalTable: "Accounts",
+                        principalColumn: "AccountId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_AccountId",
+                table: "Orders",
+                column: "AccountId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Orders");
+        }
+    }
+}

--- a/DatabaseContext/TradezillaContext.cs
+++ b/DatabaseContext/TradezillaContext.cs
@@ -9,6 +9,7 @@ namespace DatabaseContext
         public DbSet<Account> Accounts { get; set; }
         public DbSet<Asset> Assets { get; set; }
         public DbSet<Deposit> Deposits { get; set; }
+        public DbSet<Order> Orders { get; set; }
 
         public TradezillaContext(DbContextOptions<TradezillaContext> options) : base(options)
         {
@@ -20,6 +21,7 @@ namespace DatabaseContext
             modelBuilder.ApplyConfiguration(new AccountConfig());
             modelBuilder.ApplyConfiguration(new AssetConfig());
             modelBuilder.ApplyConfiguration(new DepositConfig());
+            modelBuilder.ApplyConfiguration(new OrderConfig());
         }
     }
 }

--- a/Domain/Entities/Account.cs
+++ b/Domain/Entities/Account.cs
@@ -17,6 +17,7 @@ namespace Domain.Entities
         public string? Document { get; }
         public string? Password { get; }
         public ICollection<Asset> Assets { get; }
+        public ICollection<Order> Orders { get; }
 
         private Account(Guid accountId, string? name, string? email, string? document, string? password)
         {
@@ -26,6 +27,7 @@ namespace Domain.Entities
             Document = CleanDocument(document);
             Password = password;
             Assets = new List<Asset>();
+            Orders = new List<Order>();
         }
 
         public static Account Create(string? name, string? email, string? document, string? password)

--- a/Domain/Entities/Order.cs
+++ b/Domain/Entities/Order.cs
@@ -17,6 +17,7 @@ namespace Domain.Entities
         public int FillQuantity { get; }
         public decimal FillPrice { get; }
         public DateTime CreatedAt { get; }
+        public Account? Account { get; set; }
 
         private Order(
             Guid orderId, Guid accountId, string? market, 


### PR DESCRIPTION
- Adicionada a entidade `Order` ao modelo de dados, representando pedidos associados a contas.
- Atualizada a entidade `Account` com a propriedade `Orders` e inicialização no construtor.
- Criado `OrderConfig.cs` para configurar a entidade `Order` no Entity Framework, incluindo tabela, propriedades e relacionamento com exclusão em cascata.
- Atualizado `TradezillaContext.cs` para incluir `DbSet<Order>` e aplicar configurações no método `OnModelCreating`.
- Criada a migração `20250512150741_CreateTableOrder` para gerar a tabela `Orders` no banco de dados, com colunas, chave primária, chave estrangeira e índice.
- Atualizados arquivos de snapshot e designer para refletir as mudanças no modelo.