### PR TITLE
Adiciona repositório de pedidos e abstração correspondente

### DIFF
--- a/Application/Ports/Driven/IOrderRepository.cs
+++ b/Application/Ports/Driven/IOrderRepository.cs
@@ -1,0 +1,9 @@
+﻿using Domain.Entities;
+
+namespace Application.Ports.Driven
+{
+    public interface IOrderRepository
+    {
+        void RegisterOrder(Order order);
+    }
+}

--- a/DatabaseContext/Repositories/OrderRepository.cs
+++ b/DatabaseContext/Repositories/OrderRepository.cs
@@ -1,0 +1,22 @@
+﻿using Application.Ports.Driven;
+using Domain.Entities;
+
+namespace DatabaseContext.Repositories
+{
+    public class OrderRepository : IOrderRepository
+    {
+        private readonly TradezillaContext _context;
+
+        public OrderRepository(TradezillaContext context)
+        {
+            _context = context;
+        }
+
+        public void RegisterOrder(Order order)
+        {
+            _context
+                .Orders
+                .Add(order);
+        }
+    }
+}


### PR DESCRIPTION
Introduz a interface `IOrderRepository` no namespace `Application.Ports.Driven` com o método `RegisterOrder(Order order)`.

Implementa a classe concreta `OrderRepository` no namespace `DatabaseContext.Repositories`, utilizando o contexto `TradezillaContext` para persistir pedidos na coleção `Orders`.

As alterações seguem o princípio de inversão de dependência, permitindo que a aplicação dependa de abstrações em vez de implementações específicas.