### PR TITLE
Adicionada propriedade Status à entidade Order

### DIFF
--- a/DatabaseContext/Config/OrderConfig.cs
+++ b/DatabaseContext/Config/OrderConfig.cs
@@ -36,6 +36,11 @@ namespace DatabaseContext.Config
             builder.Property(order => order.CreatedAt)
                 .IsRequired();
 
+            builder.Property(order => order.Status)
+                .HasColumnType("varchar")
+                .HasMaxLength(Order.MAX_STATUS_LENGTH)
+                .IsRequired();
+
             builder
                 .HasOne(order => order.Account)
                 .WithMany(account => account.Orders)

--- a/DatabaseContext/Migrations/20250513084212_AddColumnStatus.Designer.cs
+++ b/DatabaseContext/Migrations/20250513084212_AddColumnStatus.Designer.cs
@@ -4,6 +4,7 @@ using DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DatabaseContext.Migrations
 {
     [DbContext(typeof(TradezillaContext))]
-    partial class TradezillaContextModelSnapshot : ModelSnapshot
+    [Migration("20250513084212_AddColumnStatus")]
+    partial class AddColumnStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DatabaseContext/Migrations/20250513084212_AddColumnStatus.cs
+++ b/DatabaseContext/Migrations/20250513084212_AddColumnStatus.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DatabaseContext.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddColumnStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Orders",
+                type: "varchar(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Orders");
+        }
+    }
+}

--- a/Domain/Entities/Order.cs
+++ b/Domain/Entities/Order.cs
@@ -7,6 +7,7 @@ namespace Domain.Entities
     {
         public static readonly int MAX_MARKET_LENGTH = 7;
         public static readonly int MAX_SIDE_LENGTH = 5;
+        public static readonly int MAX_STATUS_LENGTH = 10;
         private static readonly OrderValidator _validator = new OrderValidator();
         public Guid OrderId { get; }
         public Guid AccountId { get; set; }
@@ -17,12 +18,14 @@ namespace Domain.Entities
         public int FillQuantity { get; }
         public decimal FillPrice { get; }
         public DateTime CreatedAt { get; }
+        public string? Status { get; set; }
         public Account? Account { get; set; }
 
         private Order(
             Guid orderId, Guid accountId, string? market, 
             string? side, int quantity, decimal price, 
-            int fillQuantity, decimal fillPrice, DateTime createdAt)
+            int fillQuantity, decimal fillPrice, 
+            DateTime createdAt, string? status)
         {
             OrderId = orderId;
             AccountId = accountId;
@@ -33,6 +36,7 @@ namespace Domain.Entities
             FillQuantity = fillQuantity;
             FillPrice = fillPrice;
             CreatedAt = createdAt;
+            Status = status;
         }
 
         public static Order Create(
@@ -48,7 +52,8 @@ namespace Domain.Entities
                 price,
                 fillQuantity,
                 fillPrice,
-                DateTime.UtcNow);
+                DateTime.UtcNow,
+                "open");
 
             var validationResult = _validator.Validate(newOrder);
             if (!validationResult.IsValid)

--- a/Domain/Validators/OrderValidator.cs
+++ b/Domain/Validators/OrderValidator.cs
@@ -34,6 +34,12 @@ namespace Domain.Validators
             RuleFor(order => order.CreatedAt)
                 .NotNull()
                 .WithMessage("CreatedAt cannot be null");
+
+            RuleFor(order => order.Status)
+                .NotEmpty()
+                .WithMessage("Status cannot be null, empty or whitespace")
+                .Length(1, Order.MAX_STATUS_LENGTH)
+                .WithMessage($"Status must be between 1 and {Order.MAX_STATUS_LENGTH} characters long");
         }
     }
 }


### PR DESCRIPTION
- Adicionada a propriedade `Status` na entidade `Order` com valor padrão `"open"`, tipo `string` e comprimento máximo de 10 caracteres.
- Atualizado o construtor de `Order` para incluir `Status` como parâmetro obrigatório.
- Incluídas validações para `Status` na classe `OrderValidator`.
- Configurada a propriedade `Status` no mapeamento de banco de dados em `OrderConfig.cs` como obrigatória (`IsRequired()`), tipo `varchar` e comprimento máximo de 10.
- Criada a migração `20250513084212_AddColumnStatus` para adicionar a coluna `Status` na tabela `Orders` com valor padrão vazio (`""`).
- Atualizados `TradezillaContextModelSnapshot.cs` e `20250513084212_AddColumnStatus.Designer.cs` para refletir as mudanças no modelo.
- Adicionado valor padrão `"open"` ao criar uma nova instância de `Order` no método `Order.Create`.