### PR TITLE
Refatoração: separação de domínio e modelos de banco

### DIFF
--- a/Application/UseCases/DepositUseCase.cs
+++ b/Application/UseCases/DepositUseCase.cs
@@ -31,7 +31,6 @@ namespace Application.UseCases
             if (asset is null)
             {
                 asset = Asset.Create(depositDto.AccountId, depositDto.AssetName);
-                _assetRepository.Insert(asset);
             }
 
             var deposit = Deposit.Create(
@@ -40,6 +39,7 @@ namespace Application.UseCases
 
             asset.AddDeposit(deposit);
 
+            _assetRepository.Insert(asset);
             await _unitOfWork.SaveChangesAsync();
         }
     }

--- a/DatabaseContext/Config/AccountConfig.cs
+++ b/DatabaseContext/Config/AccountConfig.cs
@@ -1,12 +1,12 @@
-﻿using Domain.Entities;
+﻿using DatabaseContext.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace DatabaseContext.Config
 {
-    public class AccountConfig : IEntityTypeConfiguration<Account>
+    public class AccountConfig : IEntityTypeConfiguration<AccountModel>
     {
-        public void Configure(EntityTypeBuilder<Account> builder)
+        public void Configure(EntityTypeBuilder<AccountModel> builder)
         {
             builder.ToTable("Accounts");
 
@@ -14,25 +14,19 @@ namespace DatabaseContext.Config
 
             builder.Property(x => x.Name)
                 .HasColumnType("varchar")
-                .HasMaxLength(Account.MAX_NAME_LENGTH);
+                .HasMaxLength(100);
 
             builder.Property(x => x.Email)
                 .HasColumnType("varchar")
-                .HasMaxLength(Account.MAX_EMAIL_LENGTH);
+                .HasMaxLength(50);
 
             builder.Property(x => x.Document)
                 .HasColumnType("varchar")
-                .HasMaxLength(Account.MAX_DOCUMENT_LENGTH);
+                .HasMaxLength(11);
 
             builder.Property(x => x.Password)
                 .HasColumnType("varchar")
-                .HasMaxLength(Account.MAX_PASSWORD_LENGTH);
-
-            builder.Navigation(nameof(Account.Assets))
-                .HasField("_assets");
-
-            builder.Navigation(nameof(Account.Orders))
-                .HasField("_orders");
+                .HasMaxLength(14);
 
             builder.HasIndex(x => x.Document)
                 .IsUnique();

--- a/DatabaseContext/Config/AssetConfig.cs
+++ b/DatabaseContext/Config/AssetConfig.cs
@@ -1,12 +1,12 @@
-﻿using Domain.Entities;
+﻿using DatabaseContext.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace DatabaseContext.Config
 {
-    public class AssetConfig : IEntityTypeConfiguration<Asset>
+    public class AssetConfig : IEntityTypeConfiguration<AssetModel>
     {
-        public void Configure(EntityTypeBuilder<Asset> builder)
+        public void Configure(EntityTypeBuilder<AssetModel> builder)
         {
             builder
                 .ToTable("Assets");
@@ -18,7 +18,7 @@ namespace DatabaseContext.Config
                 .Property(asset => asset.AssetName)
                 .IsRequired()
                 .HasColumnType("varchar")
-                .HasMaxLength(Asset.MAX_ASSETNAME_LENGTH);
+                .HasMaxLength(5);
 
             builder.Property(d => d.Balance)
                 .HasColumnType("decimal(18,2)");

--- a/DatabaseContext/Config/DepositConfig.cs
+++ b/DatabaseContext/Config/DepositConfig.cs
@@ -1,12 +1,12 @@
-﻿using Domain.Entities;
+﻿using DatabaseContext.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace DatabaseContext.Config
 {
-    public class DepositConfig : IEntityTypeConfiguration<Deposit>
+    public class DepositConfig : IEntityTypeConfiguration<DepositModel>
     {
-        public void Configure(EntityTypeBuilder<Deposit> builder)
+        public void Configure(EntityTypeBuilder<DepositModel> builder)
         {
             builder.ToTable("Deposits");
             

--- a/DatabaseContext/Config/OrderConfig.cs
+++ b/DatabaseContext/Config/OrderConfig.cs
@@ -1,24 +1,24 @@
-﻿using Domain.Entities;
+﻿using DatabaseContext.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace DatabaseContext.Config
 {
-    public class OrderConfig : IEntityTypeConfiguration<Order>
+    public class OrderConfig : IEntityTypeConfiguration<OrderModel>
     {
-        public void Configure(EntityTypeBuilder<Order> builder)
+        public void Configure(EntityTypeBuilder<OrderModel> builder)
         {
             builder.ToTable("Orders");
             builder.HasKey(order => order.OrderId);
 
             builder.Property(order => order.Market)
                 .HasColumnType("varchar")
-                .HasMaxLength(Order.MAX_MARKET_LENGTH)
+                .HasMaxLength(7)
                 .IsRequired();
 
             builder.Property(order => order.Side)
                 .HasColumnType("varchar")
-                .HasMaxLength(Order.MAX_SIDE_LENGTH)
+                .HasMaxLength(5)
                 .IsRequired();
 
             builder.Property(order => order.Quantity)
@@ -38,7 +38,7 @@ namespace DatabaseContext.Config
 
             builder.Property(order => order.Status)
                 .HasColumnType("varchar")
-                .HasMaxLength(Order.MAX_STATUS_LENGTH)
+                .HasMaxLength(10)
                 .IsRequired();
 
             builder

--- a/DatabaseContext/Mappers/AccountMapper.cs
+++ b/DatabaseContext/Mappers/AccountMapper.cs
@@ -1,0 +1,29 @@
+﻿using DatabaseContext.Models;
+using Domain.Entities;
+
+namespace DatabaseContext.Mappers
+{
+    public static class AccountMapper
+    {
+        public static AccountModel ToModel(Account account)
+        {
+            return new AccountModel
+            {
+                AccountId = account.AccountId,
+                Name = account.Name,
+                Email = account.Email,
+                Document = account.Document,
+                Password = account.Password,
+                Assets = account.Assets.Select(a => AssetMapper.ToModel(a)).ToList(),
+                Orders = account.Orders.Select(o => OrderMapper.ToModel(o)).ToList()
+            };
+        }
+
+        public static Account ToDomain(AccountModel accountModel)
+        {
+            var assets = accountModel.Assets.Select(a => AssetMapper.ToDomain(a)).ToList();
+            var orders = accountModel.Orders.Select(o => OrderMapper.ToDomain(o)).ToList();
+            return new Account(accountModel.AccountId, accountModel.Name, accountModel.Email, accountModel.Document, accountModel.Password, assets, orders);
+        }
+    }
+}

--- a/DatabaseContext/Mappers/AssetMapper.cs
+++ b/DatabaseContext/Mappers/AssetMapper.cs
@@ -1,0 +1,26 @@
+﻿using DatabaseContext.Models;
+using Domain.Entities;
+
+namespace DatabaseContext.Mappers
+{
+    public static class AssetMapper
+    {
+        public static AssetModel ToModel(Asset asset)
+        {
+            return new AssetModel
+            {
+                AssetId = asset.AssetId,
+                AccountId = asset.AccountId,
+                AssetName = asset.AssetName,
+                Balance = asset.Balance,
+                Deposits = asset.Deposits.Select(d => DepositMapper.ToModel(d)).ToList()
+            };
+        }
+
+        public static Asset ToDomain(AssetModel assetModel)
+        {
+            var deposits = assetModel.Deposits.Select(d => DepositMapper.ToDomain(d)).ToList();
+            return new Asset(assetModel.AssetId, assetModel.AccountId, assetModel.AssetName, deposits);
+        }
+    }
+}

--- a/DatabaseContext/Mappers/DepositMapper.cs
+++ b/DatabaseContext/Mappers/DepositMapper.cs
@@ -1,0 +1,23 @@
+﻿using DatabaseContext.Models;
+using Domain.Entities;
+
+namespace DatabaseContext.Mappers
+{
+    public static class DepositMapper
+    {
+        public static DepositModel ToModel(Deposit deposit)
+        {
+            return new DepositModel
+            {
+                DepositId = deposit.DepositId,
+                AssetId = deposit.AssetId,
+                Quantity = deposit.Quantity,
+            };
+        }
+
+        public static Deposit ToDomain(DepositModel depositModel)
+        {
+            return new Deposit(depositModel.DepositId, depositModel.AssetId, depositModel.Quantity);
+        }
+    }
+}

--- a/DatabaseContext/Mappers/OrderMapper.cs
+++ b/DatabaseContext/Mappers/OrderMapper.cs
@@ -1,0 +1,38 @@
+﻿using DatabaseContext.Models;
+using Domain.Entities;
+
+namespace DatabaseContext.Mappers
+{
+    public static class OrderMapper
+    {
+        public static OrderModel ToModel(Order order)
+        {
+            return new OrderModel
+            {
+                OrderId = order.OrderId,
+                AccountId = order.AccountId,
+                Market = order.Market,
+                Side = order.Side,
+                Quantity = order.Quantity,
+                Price = order.Price,
+                FillQuantity = order.FillQuantity,
+                FillPrice = order.FillPrice,
+                CreatedAt = order.CreatedAt,
+                Status = order.Status
+            };
+        }
+
+        public static Order ToDomain(OrderModel orderModel)
+        {
+            return new Order(
+                orderModel.OrderId,
+                orderModel.AccountId,
+                orderModel.Market,
+                orderModel.Side,
+                orderModel.Quantity,
+                orderModel.Price,
+                orderModel.CreatedAt,
+                orderModel.Status);
+        }
+    }
+}

--- a/DatabaseContext/Models/AccountModel.cs
+++ b/DatabaseContext/Models/AccountModel.cs
@@ -1,0 +1,13 @@
+﻿namespace DatabaseContext.Models
+{
+    public class AccountModel
+    {
+        public Guid AccountId { get; set; }
+        public string? Name { get; set; }
+        public string? Email { get; set; }
+        public string? Document { get; set; }
+        public string? Password { get; set; }
+        public ICollection<AssetModel> Assets { get; set; } = [];
+        public ICollection<OrderModel> Orders { get; set; } = [];
+    }
+}

--- a/DatabaseContext/Models/AssetModel.cs
+++ b/DatabaseContext/Models/AssetModel.cs
@@ -1,0 +1,12 @@
+﻿namespace DatabaseContext.Models
+{
+    public class AssetModel
+    {
+        public Guid AssetId { get; set; }
+        public Guid AccountId { get; set; }
+        public string? AssetName { get; set; }
+        public decimal Balance { get; set; }
+        public AccountModel? Account { get; set; }
+        public ICollection<DepositModel> Deposits { get; set; } = [];
+    }
+}

--- a/DatabaseContext/Models/DepositModel.cs
+++ b/DatabaseContext/Models/DepositModel.cs
@@ -1,0 +1,10 @@
+﻿namespace DatabaseContext.Models
+{
+    public class DepositModel
+    {
+        public Guid DepositId { get; set; }
+        public Guid AssetId { get; set; }
+        public decimal Quantity { get; set; }
+        public AssetModel? Asset { get; set; }
+    }
+}

--- a/DatabaseContext/Models/OrderModel.cs
+++ b/DatabaseContext/Models/OrderModel.cs
@@ -1,0 +1,17 @@
+﻿namespace DatabaseContext.Models
+{
+    public class OrderModel
+    {
+        public Guid OrderId { get; set; }
+        public Guid AccountId { get; set; }
+        public string? Market { get; set; }
+        public string? Side { get; set; }
+        public int Quantity { get; set; }
+        public decimal Price { get; set; }
+        public int FillQuantity { get; set; }
+        public decimal FillPrice { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string? Status { get; set; }
+        public AccountModel? Account { get; set; }
+    }
+}

--- a/DatabaseContext/Repositories/AccountRepository.cs
+++ b/DatabaseContext/Repositories/AccountRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Ports.Driven;
+using DatabaseContext.Mappers;
 using Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,25 +16,32 @@ namespace DatabaseContext.Repositories
 
         public void RegisterAccount(Account account)
         {
+            var accountModel = AccountMapper.ToModel(account);
+
             _context
                 .Accounts
-                .Add(account);
+                .Add(accountModel);
         }
 
         public async Task<Account?> GetAccountByDocumentAsync(string document)
         {
-            return await _context
+            var accountModel = await _context
                 .Accounts
                 .FirstOrDefaultAsync(a => a.Document == document);
+
+            return accountModel is null ? null : AccountMapper.ToDomain(accountModel);
         }
 
         public async Task<Account?> GetAccountByAccountIdAsync(Guid accountId)
         {
-            return await _context
+            var accountModel = await _context
                 .Accounts
                 .Include(a => a.Assets)
+                    .ThenInclude(asset => asset.Deposits)
                 .Include(a => a.Orders)
                 .FirstOrDefaultAsync(a => a.AccountId == accountId);
+
+            return accountModel is null ? null : AccountMapper.ToDomain(accountModel);
         }
     }
 }

--- a/DatabaseContext/Repositories/AssetRepository.cs
+++ b/DatabaseContext/Repositories/AssetRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Ports.Driven;
+using DatabaseContext.Mappers;
 using Domain.Entities;
 
 namespace DatabaseContext.Repositories
@@ -14,7 +15,8 @@ namespace DatabaseContext.Repositories
 
         public void Insert(Asset asset)
         {
-            _context.Assets.Add(asset);
+            var assetModel = AssetMapper.ToModel(asset);
+            _context.Assets.Add(assetModel);
         }
     }
 }

--- a/DatabaseContext/Repositories/OrderRepository.cs
+++ b/DatabaseContext/Repositories/OrderRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Ports.Driven;
+using DatabaseContext.Mappers;
 using Domain.Entities;
 
 namespace DatabaseContext.Repositories
@@ -14,9 +15,8 @@ namespace DatabaseContext.Repositories
 
         public void RegisterOrder(Order order)
         {
-            _context
-                .Orders
-                .Add(order);
+            var orderModel = OrderMapper.ToModel(order);
+            _context.Orders.Add(orderModel);
         }
     }
 }

--- a/DatabaseContext/TradezillaContext.cs
+++ b/DatabaseContext/TradezillaContext.cs
@@ -1,15 +1,15 @@
 ﻿using DatabaseContext.Config;
-using Domain.Entities;
+using DatabaseContext.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace DatabaseContext
 {
     public class TradezillaContext : DbContext
     {
-        public DbSet<Account> Accounts { get; set; }
-        public DbSet<Asset> Assets { get; set; }
-        public DbSet<Deposit> Deposits { get; set; }
-        public DbSet<Order> Orders { get; set; }
+        public DbSet<AccountModel> Accounts { get; set; }
+        public DbSet<AssetModel> Assets { get; set; }
+        public DbSet<DepositModel> Deposits { get; set; }
+        public DbSet<OrderModel> Orders { get; set; }
 
         public TradezillaContext(DbContextOptions<TradezillaContext> options) : base(options)
         {

--- a/Domain/Entities/Account.cs
+++ b/Domain/Entities/Account.cs
@@ -10,8 +10,8 @@ namespace Domain.Entities
         public static readonly int MAX_DOCUMENT_LENGTH = 11;
         public static readonly int MAX_PASSWORD_LENGTH = 14;
         private static readonly AccountValidator _validator = new AccountValidator();
-        private readonly List<Order> _orders;
-        private readonly List<Asset> _assets;
+        private readonly List<Asset> _assets = [];
+        private readonly List<Order> _orders = [];
 
         public Guid AccountId { get; }
         public string? Name { get; }
@@ -21,20 +21,28 @@ namespace Domain.Entities
         public IReadOnlyCollection<Asset> Assets => _assets.AsReadOnly();
         public IReadOnlyCollection<Order> Orders => _orders.AsReadOnly();
 
-        private Account(Guid accountId, string? name, string? email, string? document, string? password)
+        public Account(Guid accountId, string? name, string? email, string? document, string? password, List<Asset> assets, List<Order> orders)
         {
             AccountId = accountId;
             Name = name;
             Email = email;
             Document = CleanDocument(document);
             Password = password;
-            _assets = [];
-            _orders = [];
+
+            foreach (var asset in assets)
+            {
+                AddAsset(asset);
+            }
+
+            foreach (var order in orders)
+            {
+                AddOrder(order);
+            }
         }
 
         public static Account Create(string? name, string? email, string? document, string? password)
         {
-            var newAccount = new Account(Guid.NewGuid(), name, email, document, password);
+            var newAccount = new Account(Guid.NewGuid(), name, email, document, password, [], []);
             var validationResult = _validator.Validate(newAccount);
             if (!validationResult.IsValid)
             {

--- a/Domain/Entities/Asset.cs
+++ b/Domain/Entities/Asset.cs
@@ -7,26 +7,31 @@ namespace Domain.Entities
     {
         public static readonly int MAX_ASSETNAME_LENGTH = 5;
         private static readonly AssetValidator _validator = new AssetValidator();
+        private readonly List<Deposit> _deposits = [];
 
         public Guid AssetId { get; set; }
         public Guid AccountId { get; set; }
         public string? AssetName { get; set; }
         public decimal Balance { get; private set; }
         public Account? Account { get; set; }
-        public ICollection<Deposit> Deposits { get; set; }
+        public IReadOnlyCollection<Deposit> Deposits => _deposits.AsReadOnly();
 
-        private Asset(Guid assetId, Guid accountId, string? assetName)
+        public Asset(Guid assetId, Guid accountId, string? assetName, List<Deposit> deposits)
         {
             AssetId = assetId;
             AccountId = accountId;
             AssetName = assetName;
             Balance = 0;
-            Deposits = new List<Deposit>();
+
+            foreach (var deposit in deposits)
+            {
+                AddDeposit(deposit);
+            }
         }
 
         public static Asset Create(Guid accountId, string? assetName)
         {
-            var newAsset =  new Asset(Guid.NewGuid(), accountId, assetName);
+            var newAsset =  new Asset(Guid.NewGuid(), accountId, assetName, []);
             var validationResult = _validator.Validate(newAsset);
             if (!validationResult.IsValid)
             {
@@ -38,7 +43,7 @@ namespace Domain.Entities
 
         public void AddDeposit(Deposit deposit)
         {
-            Deposits.Add(deposit);
+            _deposits.Add(deposit);
             Balance += deposit.Quantity;
         }
     }

--- a/Domain/Entities/Deposit.cs
+++ b/Domain/Entities/Deposit.cs
@@ -11,7 +11,7 @@ namespace Domain.Entities
         public decimal Quantity { get; }
         public Asset? Asset { get; }
 
-        private Deposit(Guid depositId, Guid assetId, decimal quantity)
+        public Deposit(Guid depositId, Guid assetId, decimal quantity)
         {
             DepositId = depositId;
             AssetId = assetId;

--- a/Domain/Entities/Order.cs
+++ b/Domain/Entities/Order.cs
@@ -21,7 +21,7 @@ namespace Domain.Entities
         public string? Status { get; set; }
         public Account? Account { get; set; }
 
-        private Order(
+        public Order(
             Guid orderId, Guid accountId, string? market, 
             string? side, int quantity, decimal price, 
             DateTime createdAt, string? status)


### PR DESCRIPTION
Refatoração para separar entidades do domínio e modelos de banco.
- Criados modelos de banco (`AccountModel`, `AssetModel`, etc.)
- Adicionados mapeadores para conversão entre domínio e modelos.
- Repositórios atualizados para usar os modelos e mapeadores.
- Configurações do Entity Framework ajustadas para os novos modelos.
- `DbContext` atualizado para usar `DbSet` dos modelos de banco.
- Entidades do domínio ajustadas para encapsulamento e imutabilidade.
- Casos de uso e repositórios adaptados para a nova estrutura.
- Removidas dependências do domínio em classes de banco de dados.

Essas mudanças promovem separação de responsabilidades, melhoram a manutenção e centralizam a lógica de conversão entre objetos.