### PR TITLE
Renomeia Deposit para Transaction e ajusta propriedades

### DIFF
--- a/Application/DTOs/TransactionDto.cs
+++ b/Application/DTOs/TransactionDto.cs
@@ -4,6 +4,6 @@
     {
         public Guid AccountId { get; set; }
         public string? AssetName { get; set; }
-        public decimal Value { get; set; }
+        public decimal Quantity { get; set; }
     }
 }

--- a/Application/UseCases/TransactionUseCase.cs
+++ b/Application/UseCases/TransactionUseCase.cs
@@ -27,7 +27,7 @@ namespace Application.UseCases
 
             var transaction = Transaction.Create(
                 asset.AssetId,
-                transactionDto.Value);
+                transactionDto.Quantity);
 
             asset.AddTransation(transaction);
 

--- a/DatabaseContext/Config/TransactionConfig.cs
+++ b/DatabaseContext/Config/TransactionConfig.cs
@@ -8,9 +8,9 @@ namespace DatabaseContext.Config
     {
         public void Configure(EntityTypeBuilder<TransactionModel> builder)
         {
-            builder.ToTable("Deposits");
+            builder.ToTable("Transactions");
             
-            builder.HasKey(d => d.DepositId);
+            builder.HasKey(d => d.TransactionId);
 
             builder.Property(d => d.Quantity)
                 .HasColumnType("decimal(18,2)");

--- a/DatabaseContext/Mappers/TransactionMapper.cs
+++ b/DatabaseContext/Mappers/TransactionMapper.cs
@@ -9,15 +9,15 @@ namespace DatabaseContext.Mappers
         {
             return new TransactionModel
             {
-                DepositId = deposit.TransactionId,
+                TransactionId = deposit.TransactionId,
                 AssetId = deposit.AssetId,
-                Quantity = deposit.Value,
+                Quantity = deposit.Quantity,
             };
         }
 
         public static Transaction ToDomain(TransactionModel depositModel)
         {
-            return new Transaction(depositModel.DepositId, depositModel.AssetId, depositModel.Quantity);
+            return new Transaction(depositModel.TransactionId, depositModel.AssetId, depositModel.Quantity);
         }
     }
 }

--- a/DatabaseContext/Migrations/20250518185627_ChangeDepositToTransaction.Designer.cs
+++ b/DatabaseContext/Migrations/20250518185627_ChangeDepositToTransaction.Designer.cs
@@ -4,6 +4,7 @@ using DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DatabaseContext.Migrations
 {
     [DbContext(typeof(TradezillaContext))]
-    partial class TradezillaContextModelSnapshot : ModelSnapshot
+    [Migration("20250518185627_ChangeDepositToTransaction")]
+    partial class ChangeDepositToTransaction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DatabaseContext/Migrations/20250518185627_ChangeDepositToTransaction.cs
+++ b/DatabaseContext/Migrations/20250518185627_ChangeDepositToTransaction.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DatabaseContext.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeDepositToTransaction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Deposits");
+
+            migrationBuilder.CreateTable(
+                name: "Transactions",
+                columns: table => new
+                {
+                    TransactionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Quantity = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Transactions", x => x.TransactionId);
+                    table.ForeignKey(
+                        name: "FK_Transactions_Assets_AssetId",
+                        column: x => x.AssetId,
+                        principalTable: "Assets",
+                        principalColumn: "AssetId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Transactions_AssetId",
+                table: "Transactions",
+                column: "AssetId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Transactions");
+
+            migrationBuilder.CreateTable(
+                name: "Deposits",
+                columns: table => new
+                {
+                    DepositId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AssetId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Quantity = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Deposits", x => x.DepositId);
+                    table.ForeignKey(
+                        name: "FK_Deposits_Assets_AssetId",
+                        column: x => x.AssetId,
+                        principalTable: "Assets",
+                        principalColumn: "AssetId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Deposits_AssetId",
+                table: "Deposits",
+                column: "AssetId");
+        }
+    }
+}

--- a/DatabaseContext/Models/TransactionModel.cs
+++ b/DatabaseContext/Models/TransactionModel.cs
@@ -2,7 +2,7 @@
 {
     public class TransactionModel
     {
-        public Guid DepositId { get; set; }
+        public Guid TransactionId { get; set; }
         public Guid AssetId { get; set; }
         public decimal Quantity { get; set; }
         public AssetModel? Asset { get; set; }

--- a/Domain/Entities/Asset.cs
+++ b/Domain/Entities/Asset.cs
@@ -44,7 +44,7 @@ namespace Domain.Entities
         public void AddTransation(Transaction transation)
         {
             _transactions.Add(transation);
-            Balance += transation.Value;
+            Balance += transation.Quantity;
         }
     }
 }

--- a/Domain/Entities/Transaction.cs
+++ b/Domain/Entities/Transaction.cs
@@ -8,19 +8,19 @@ namespace Domain.Entities
         private static readonly TransactionValidator _validator = new TransactionValidator();
         public Guid TransactionId { get; }
         public Guid AssetId { get; }
-        public decimal Value { get; }
+        public decimal Quantity { get; }
         public Asset? Asset { get; }
 
-        public Transaction(Guid transactionId, Guid assetId, decimal value)
+        public Transaction(Guid transactionId, Guid assetId, decimal quantity)
         {
             TransactionId = transactionId;
             AssetId = assetId;
-            Value = value;
+            Quantity = quantity;
         }
 
-        public static Transaction Create(Guid assetId, decimal value)
+        public static Transaction Create(Guid assetId, decimal quantity)
         {
-            var newTransaction = new Transaction(Guid.NewGuid(), assetId, value);
+            var newTransaction = new Transaction(Guid.NewGuid(), assetId, quantity);
             var validationResult = _validator.Validate(newTransaction);
             if (!validationResult.IsValid)
             {

--- a/Domain/Validators/TransactionValidator.cs
+++ b/Domain/Validators/TransactionValidator.cs
@@ -11,7 +11,7 @@ namespace Domain.Validators
                 .NotEmpty()
                 .WithMessage("AssetId cannot be empty");
 
-            RuleFor(transaction => transaction.Value)
+            RuleFor(transaction => transaction.Quantity)
                 .NotEqual(0)
                 .WithMessage("Value cannot be 0");
         }

--- a/Tests/Integration/BaseControllerTests.cs
+++ b/Tests/Integration/BaseControllerTests.cs
@@ -71,7 +71,7 @@ namespace Tests.Integration
             {
                 AccountId = accountId,
                 AssetName = assetName,
-                Value = value
+                Quantity = value
             });
 
             var transactionContent = new StringContent(transactionJson, Encoding.UTF8, "application/json");

--- a/Tests/Integration/TransactionControllerTests.cs
+++ b/Tests/Integration/TransactionControllerTests.cs
@@ -18,7 +18,7 @@ namespace Tests.Integration
             {
                 AccountId = accountId,
                 AssetName = "BTC",
-                Value = 10
+                Quantity = 10
             });
             var transactionContent = new StringContent(transactionJson, Encoding.UTF8, "application/json");
             await _client.PostAsync(transactionRequestUri, transactionContent);
@@ -53,7 +53,7 @@ namespace Tests.Integration
             var json = JsonConvert.SerializeObject(new
             {
                 AssetName = "BTC",
-                Value = 10
+                Quantity = 10
             });
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
@@ -76,7 +76,7 @@ namespace Tests.Integration
             {
                 AccountId = Guid.Empty,
                 AssetName = "BTC",
-                Value = 10
+                Quantity = 10
             });
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
@@ -104,7 +104,7 @@ namespace Tests.Integration
             {
                 AccountId = accountId,
                 AssetName = assetName,
-                Value = 10
+                Quantity = 10
             });
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
@@ -129,7 +129,7 @@ namespace Tests.Integration
             {
                 AccountId = accountId,
                 AssetName = "BTC",
-                Value = 0
+                Quantity = 0
             });
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 

--- a/Tests/Unit/Entities/TransactionTests.cs
+++ b/Tests/Unit/Entities/TransactionTests.cs
@@ -21,7 +21,7 @@ namespace Tests.Unit.Entities
             transaction.Should().NotBeNull();
             transaction.TransactionId.Should().NotBeEmpty();
             transaction.AssetId.Should().Be(assetId);
-            transaction.Value.Should().Be(value);
+            transaction.Quantity.Should().Be(value);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Tests.Unit.Entities
 
             // Assert
             transaction.Should().NotBeNull();
-            transaction.Value.Should().Be(value);
+            transaction.Quantity.Should().Be(value);
         }
     }
 } 


### PR DESCRIPTION
Substitui o termo "Deposit" por "Transaction" em todo o código, refletindo mudanças no domínio do sistema. Atualiza propriedades, como `Value` para `Quantity`, em classes, entidades e casos de uso.

Renomeia a tabela `Deposits` para `Transactions` e ajusta chaves primárias e relações no modelo de dados. Cria migração `20250518185627_ChangeDepositToTransaction` para aplicar as mudanças no banco de dados.

Atualiza testes unitários e de integração para refletir as mudanças de nomenclatura e propriedades. Ajusta cálculos e validações para usar `Quantity` em vez de `Value`.