### PR TITLE
Adiciona repositório de pedidos e interface associada

### DIFF
--- a/Application/Ports/Driven/IOrderRepository.cs
+++ b/Application/Ports/Driven/IOrderRepository.cs
@@ -1,0 +1,9 @@
+﻿using Domain.Entities;
+
+namespace Application.Ports.Driven
+{
+    public interface IOrderRepository
+    {
+        Task<List<Order>?> GetOrdersByMarketIdAsync(string marketId);
+    }
+}

--- a/DatabaseContext/Repositories/OrderRepository.cs
+++ b/DatabaseContext/Repositories/OrderRepository.cs
@@ -1,0 +1,26 @@
+﻿using Application.Ports.Driven;
+using DatabaseContext.Mappers;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DatabaseContext.Repositories
+{
+    public class OrderRepository : IOrderRepository
+    {
+        private readonly TradezillaContext _context;
+
+        public OrderRepository(TradezillaContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<Order>?> GetOrdersByMarketIdAsync(string marketId)
+        {
+            var ordersModel = await _context.Orders
+                .Where(o => o.Market == marketId)
+                .ToListAsync();
+
+            return ordersModel?.Select(o => OrderMapper.ToDomain(o)).ToList();
+        }
+    }
+}


### PR DESCRIPTION
Adicionada a interface `IOrderRepository` no namespace `Application.Ports.Driven`, com o método assíncrono `GetOrdersByMarketIdAsync` para buscar pedidos por `marketId`.

Implementada a classe `OrderRepository` no namespace `DatabaseContext.Repositories`, que utiliza o contexto `TradezillaContext` e o `OrderMapper` para acessar e mapear dados do banco de dados para o domínio.