### PR TITLE
Implementação de execução de ordens no mercado

### DIFF
--- a/API/Program.cs
+++ b/API/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddScoped<IDebit, DebitUseCase>();
 builder.Services.AddScoped<IGetAccount, GetAccountUseCase>();
 builder.Services.AddScoped<IPlaceOrder, PlaceOrderUseCase>();
 builder.Services.AddScoped<IGetDepth, GetDepthUseCase>();
+builder.Services.AddScoped<IExecuteOrder, ExecuteOrderUseCase>();
 builder.Services.AddScoped<IAccountRepository, AccountRepository>();
 builder.Services.AddScoped<IAssetRepository, AssetRepository>();
 builder.Services.AddScoped<IOrderRepository, OrderRepository>();

--- a/Application/Ports/Driven/IOrderRepository.cs
+++ b/Application/Ports/Driven/IOrderRepository.cs
@@ -5,5 +5,7 @@ namespace Application.Ports.Driven
     public interface IOrderRepository
     {
         Task<List<Order>?> GetOrdersByMarketIdAsync(string marketId);
+        Task<List<Order>?> GetOrdersOpensByMarketIdAsync(string marketId);
+        void UpdateOrderExecuted(Order order);
     }
 }

--- a/Application/Ports/Driving/IExecuteOrder.cs
+++ b/Application/Ports/Driving/IExecuteOrder.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Ports.Driving
+{
+    public interface IExecuteOrder
+    {
+        Task ExecuteOrderAsync(string marketId);
+    }
+}

--- a/Application/UseCases/ExecuteOrderUseCase.cs
+++ b/Application/UseCases/ExecuteOrderUseCase.cs
@@ -1,0 +1,41 @@
+﻿using Application.Ports.Driven;
+using Application.Ports.Driving;
+
+namespace Application.UseCases
+{
+    public class ExecuteOrderUseCase : IExecuteOrder
+    {
+        private readonly IOrderRepository _orderRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ExecuteOrderUseCase(IOrderRepository orderRepository, IUnitOfWork unitOfWork)
+        {
+            _orderRepository = orderRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task ExecuteOrderAsync(string marketId)
+        {
+            var orders = await _orderRepository.GetOrdersOpensByMarketIdAsync(marketId);
+
+            var highestBuy = orders?.Where(x => x.Side!.ToUpper() == "BUY").OrderByDescending(o => o.Price).FirstOrDefault();
+            var lowestSell = orders?.Where(x => x.Side!.ToUpper() == "SELL").OrderByDescending(o => o.Price).FirstOrDefault();
+            if (highestBuy is null || lowestSell is null || highestBuy.Price < lowestSell.Price)
+            {
+                return;
+            }
+
+            var fillQuantity = Math.Min(highestBuy.Quantity, lowestSell.Quantity);
+            var fillPrice = highestBuy.CreatedAt > lowestSell.CreatedAt ? lowestSell.Price : highestBuy.Price;
+            var tradeSide = highestBuy.CreatedAt > lowestSell.CreatedAt ? "BUY" : "SELL";
+
+            highestBuy.SetFillQuantity(fillQuantity);
+            lowestSell.SetFillQuantity(fillQuantity);
+
+            _orderRepository.UpdateOrderExecuted(highestBuy);
+            _orderRepository.UpdateOrderExecuted(lowestSell);
+
+            await _unitOfWork.SaveChangesAsync();
+        }
+    }
+}

--- a/Application/UseCases/GetDepthUseCase.cs
+++ b/Application/UseCases/GetDepthUseCase.cs
@@ -16,7 +16,7 @@ namespace Application.UseCases
 
         public async Task<DepthDto> ExecuteAsync(string marketId, int precision)
         {
-            var orders = await _orderRepository.GetOrdersByMarketIdAsync(marketId);
+            var orders = await _orderRepository.GetOrdersOpensByMarketIdAsync(marketId);
             var index = Order.GroupOrdersByPrecision(orders, precision);
 
             var depthDto = new DepthDto();

--- a/Application/UseCases/PlaceOrderUseCase.cs
+++ b/Application/UseCases/PlaceOrderUseCase.cs
@@ -10,13 +10,16 @@ namespace Application.UseCases
     {
         private readonly IAccountRepository _accountRepository;
         private readonly IUnitOfWork _unitOfWork;
+        private readonly IExecuteOrder _executeOrder;
 
         public PlaceOrderUseCase(
             IAccountRepository accountRepository,
-            IUnitOfWork unitOfWork)
+            IUnitOfWork unitOfWork,
+            IExecuteOrder executeOrder)
         {
             _accountRepository = accountRepository;
             _unitOfWork = unitOfWork;
+            _executeOrder = executeOrder;
         }
 
         public async Task<Guid> PlaceOrder(PlaceOrderDto placeOrderDto)
@@ -38,6 +41,8 @@ namespace Application.UseCases
 
             await _accountRepository.RegisterOrdersAsync(account);
             await _unitOfWork.SaveChangesAsync();
+
+            await _executeOrder.ExecuteOrderAsync(placeOrderDto.MarketId!);
 
             return order.OrderId;
         }

--- a/Domain/Entities/Order.cs
+++ b/Domain/Entities/Order.cs
@@ -15,8 +15,8 @@ namespace Domain.Entities
         public string? Side { get; }
         public int Quantity { get; }
         public decimal Price { get; }
-        public int FillQuantity { get; }
-        public decimal FillPrice { get; }
+        public int FillQuantity { get; private set; }
+        public decimal FillPrice { get; private set; }
         public DateTime CreatedAt { get; }
         public string? Status { get; set; }
         public Account? Account { get; set; }
@@ -98,6 +98,31 @@ namespace Domain.Entities
             }
 
             return index;
+        }
+
+        public void SetFillQuantity(int quantity)
+        {
+            if (quantity < 0)
+            {
+                throw new ArgumentException("Fill quantity cannot be negative");
+            }
+
+            FillQuantity = quantity;
+
+            if (FillQuantity == Quantity)
+            {
+                Status = "closed";
+            }
+        }
+
+        public void SetFillPrice(decimal price)
+        {
+            if (price < 0)
+            {
+                throw new ArgumentException("Fill price cannot be negative");
+            }
+
+            FillPrice = price;
         }
     }
 }

--- a/Tests/Unit/UseCase/PlaceOrderTests.cs
+++ b/Tests/Unit/UseCase/PlaceOrderTests.cs
@@ -1,5 +1,6 @@
 ﻿using Application.DTOs;
 using Application.Ports.Driven;
+using Application.Ports.Driving;
 using Application.UseCases;
 using Domain.Entities;
 using Domain.Enums;
@@ -13,15 +14,18 @@ namespace Tests.Unit.UseCase
         private readonly Mock<IAccountRepository> _accountRepositoryMock;
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
         private readonly PlaceOrderUseCase _placeOrderUseCase;
+        private readonly Mock<IExecuteOrder> _executeOrderMock;
 
         public PlaceOrderTests()
         {
             _accountRepositoryMock = new Mock<IAccountRepository>();
             _unitOfWorkMock = new Mock<IUnitOfWork>();
+            _executeOrderMock = new Mock<IExecuteOrder>();
 
             _placeOrderUseCase = new PlaceOrderUseCase(
                 _accountRepositoryMock.Object,
-                _unitOfWorkMock.Object);
+                _unitOfWorkMock.Object,
+                _executeOrderMock.Object);
         }
 
         [Fact]


### PR DESCRIPTION
Adicionada a interface `IExecuteOrder` e o caso de uso `ExecuteOrderUseCase` para execução de ordens de compra e venda. Atualizações no repositório e na entidade `Order` para suportar a lógica de execução, incluindo métodos para buscar e atualizar ordens no banco de dados.

Alterado o `PlaceOrderUseCase` para chamar `ExecuteOrderAsync` após salvar uma nova ordem. Ajustado o `GetDepthUseCase` para considerar apenas ordens abertas.

Adicionados testes de integração em `OrderControllerTests` e ajustes nos testes unitários de `PlaceOrderTests` para refletir as mudanças.

Outras alterações incluem ajustes em namespaces, injeção de dependência no `Program.cs` e validações na entidade `Order`.