### PR TITLE
Refatoração para uso de Mediator e novo projeto EventSource

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DatabaseContext\DatabaseContext.csproj" />
+    <ProjectReference Include="..\EventSource\EventSource.csproj" />
   </ItemGroup>
 
 </Project>

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,8 +1,12 @@
+using Application.Handlers;
+using Application.Notifications;
 using Application.Ports.Driven;
+using Application.Ports.Driven.Mediator;
 using Application.Ports.Driving;
 using Application.UseCases;
 using DatabaseContext;
 using DatabaseContext.Repositories;
+using EventSource;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,6 +17,9 @@ if (!env.IsEnvironment("Testing"))
     var connectionString = builder.Configuration.GetConnectionString("SqlServerConnection");
     builder.Services.AddDbContext<TradezillaContext>(options => options.UseSqlServer(connectionString));
 }
+
+builder.Services.AddTransient<INotificationHandler<PlaceOrderNotification>, PlaceOrderHandler>();
+builder.Services.AddSingleton<IMediator, Mediator>();
 
 builder.Services.AddScoped<ISignUp, SignUpUseCase>();
 builder.Services.AddScoped<ICredit, CreditUseCase>();

--- a/Application/Handlers/PlaceOrderHandler.cs
+++ b/Application/Handlers/PlaceOrderHandler.cs
@@ -1,0 +1,21 @@
+﻿using Application.Notifications;
+using Application.Ports.Driven.Mediator;
+using Application.Ports.Driving;
+
+namespace Application.Handlers
+{
+    public class PlaceOrderHandler : INotificationHandler<PlaceOrderNotification>
+    {
+        private readonly IExecuteOrder _executeOrder;
+
+        public PlaceOrderHandler(IExecuteOrder executeOrder)
+        {
+            _executeOrder = executeOrder;
+        }
+
+        public async Task Handle(PlaceOrderNotification request)
+        {
+            await _executeOrder.ExecuteOrderAsync(request.Order.Market!);
+        }
+    }
+}

--- a/Application/Notifications/PlaceOrderNotification.cs
+++ b/Application/Notifications/PlaceOrderNotification.cs
@@ -1,0 +1,15 @@
+﻿using Application.Ports.Driven.Mediator;
+using Domain.Entities;
+
+namespace Application.Notifications
+{
+    public class PlaceOrderNotification : INotification
+    {
+        public Order Order { get; set; }
+
+        public PlaceOrderNotification(Order order)
+        {
+            Order = order;
+        }
+    }
+}

--- a/Application/Ports/Driven/Mediator/IMediator.cs
+++ b/Application/Ports/Driven/Mediator/IMediator.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Ports.Driven.Mediator
+{
+    public interface IMediator
+    {
+        Task Send<TNotification>(TNotification notification);
+    }
+}

--- a/Application/Ports/Driven/Mediator/INotification.cs
+++ b/Application/Ports/Driven/Mediator/INotification.cs
@@ -1,0 +1,4 @@
+﻿namespace Application.Ports.Driven.Mediator
+{
+    public interface INotification { }
+}

--- a/Application/Ports/Driven/Mediator/INotificationHandler.cs
+++ b/Application/Ports/Driven/Mediator/INotificationHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Ports.Driven.Mediator
+{
+    public interface INotificationHandler<TNotification> where TNotification : INotification
+    {
+        Task Handle(TNotification notification);
+    }
+}

--- a/Application/UseCases/PlaceOrderUseCase.cs
+++ b/Application/UseCases/PlaceOrderUseCase.cs
@@ -1,5 +1,7 @@
 ﻿using Application.DTOs;
+using Application.Notifications;
 using Application.Ports.Driven;
+using Application.Ports.Driven.Mediator;
 using Application.Ports.Driving;
 using Domain.Entities;
 using Domain.Exceptions;
@@ -10,16 +12,16 @@ namespace Application.UseCases
     {
         private readonly IAccountRepository _accountRepository;
         private readonly IUnitOfWork _unitOfWork;
-        private readonly IExecuteOrder _executeOrder;
+        private readonly IMediator _mediator;
 
         public PlaceOrderUseCase(
             IAccountRepository accountRepository,
             IUnitOfWork unitOfWork,
-            IExecuteOrder executeOrder)
+            IMediator mediator)
         {
             _accountRepository = accountRepository;
             _unitOfWork = unitOfWork;
-            _executeOrder = executeOrder;
+            _mediator = mediator;
         }
 
         public async Task<Guid> PlaceOrder(PlaceOrderDto placeOrderDto)
@@ -42,7 +44,7 @@ namespace Application.UseCases
             await _accountRepository.RegisterOrdersAsync(account);
             await _unitOfWork.SaveChangesAsync();
 
-            await _executeOrder.ExecuteOrderAsync(placeOrderDto.MarketId!);
+            await _mediator.Send(new PlaceOrderNotification(order));
 
             return order.OrderId;
         }

--- a/EventSource/EventSource.csproj
+++ b/EventSource/EventSource.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EventSource/Mediator.cs
+++ b/EventSource/Mediator.cs
@@ -1,0 +1,32 @@
+﻿using Application.Ports.Driven.Mediator;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EventSource
+{
+    public class Mediator : IMediator
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public Mediator(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public async Task Send<TNotification>(TNotification notification)
+        {
+            ArgumentNullException.ThrowIfNull(notification, nameof(notification));
+            var handlerType = typeof(INotificationHandler<>).MakeGenericType(notification.GetType());
+
+            var handlers = _serviceProvider.GetServices(handlerType);
+            ArgumentNullException.ThrowIfNull(handlers, nameof(handlers));
+
+            if (handlers.Any(h => h is null))
+            {
+                throw new ArgumentNullException(nameof(handlers), "One or more handlers are null");
+            }
+
+            var tasks = handlers.Select(handler => (Task)((dynamic)handler!).Handle((dynamic)notification)).ToArray();
+            await Task.WhenAll(tasks);
+        }
+    }
+}

--- a/Tests/Unit/UseCase/PlaceOrderTests.cs
+++ b/Tests/Unit/UseCase/PlaceOrderTests.cs
@@ -1,6 +1,6 @@
 ﻿using Application.DTOs;
 using Application.Ports.Driven;
-using Application.Ports.Driving;
+using Application.Ports.Driven.Mediator;
 using Application.UseCases;
 using Domain.Entities;
 using Domain.Enums;
@@ -14,18 +14,18 @@ namespace Tests.Unit.UseCase
         private readonly Mock<IAccountRepository> _accountRepositoryMock;
         private readonly Mock<IUnitOfWork> _unitOfWorkMock;
         private readonly PlaceOrderUseCase _placeOrderUseCase;
-        private readonly Mock<IExecuteOrder> _executeOrderMock;
+        private readonly Mock<IMediator> _mediatorMock;
 
         public PlaceOrderTests()
         {
             _accountRepositoryMock = new Mock<IAccountRepository>();
             _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _executeOrderMock = new Mock<IExecuteOrder>();
+            _mediatorMock = new Mock<IMediator>();
 
             _placeOrderUseCase = new PlaceOrderUseCase(
                 _accountRepositoryMock.Object,
                 _unitOfWorkMock.Object,
-                _executeOrderMock.Object);
+                _mediatorMock.Object);
         }
 
         [Fact]

--- a/Tradezilla.sln
+++ b/Tradezilla.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "Domain\Domain.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "Application\Application.csproj", "{FEEB2201-A73B-4C45-B76E-9145F4A181C8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventSource", "EventSource\EventSource.csproj", "{277E4479-22F6-4EA0-AE92-C3E675DC79F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{FEEB2201-A73B-4C45-B76E-9145F4A181C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FEEB2201-A73B-4C45-B76E-9145F4A181C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FEEB2201-A73B-4C45-B76E-9145F4A181C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{277E4479-22F6-4EA0-AE92-C3E675DC79F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{277E4479-22F6-4EA0-AE92-C3E675DC79F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{277E4479-22F6-4EA0-AE92-C3E675DC79F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{277E4479-22F6-4EA0-AE92-C3E675DC79F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,5 +61,6 @@ Global
 		{5A49713B-B236-47E6-880F-E8C46E6FBE8B} = {F52F5B6F-32DD-4B3C-8310-1E737A180A78}
 		{CCB6797A-69E9-451A-91EB-C0A7B4C5ADCD} = {A82D5B49-2C09-44DF-BAB5-0E69A0F6D438}
 		{FEEB2201-A73B-4C45-B76E-9145F4A181C8} = {A82D5B49-2C09-44DF-BAB5-0E69A0F6D438}
+		{277E4479-22F6-4EA0-AE92-C3E675DC79F3} = {F52F5B6F-32DD-4B3C-8310-1E737A180A78}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Adicionado o projeto `EventSource` com implementação do padrão Mediator, incluindo a classe `Mediator` e interfaces relacionadas (`IMediator`, `INotification`, `INotificationHandler`). Atualizado o `API.csproj` para referenciar o novo projeto.

Refatorado o caso de uso `PlaceOrderUseCase` para substituir a dependência de `IExecuteOrder` por `IMediator`, enviando notificações do tipo `PlaceOrderNotification`. Criadas as classes `PlaceOrderHandler` e `PlaceOrderNotification` para lidar com notificações.

Atualizado o `Program.cs` para registrar serviços no contêiner de DI, incluindo handlers, notificações e casos de uso. Ajustados os testes unitários para refletir as mudanças.

Atualizado o arquivo de solução `Tradezilla.sln` para incluir o projeto `EventSource`. Outras alterações menores em namespaces e importações para compatibilidade com a nova estrutura.