### PR TITLE
Refatoração: uso de `AssetId` substituído por `GetId()`

### DIFF
--- a/Application/UseCases/CreditUseCase.cs
+++ b/Application/UseCases/CreditUseCase.cs
@@ -28,7 +28,7 @@ namespace Application.UseCases
 
 
             var transaction = Transaction.Create(
-                asset.AssetId,
+                asset.GetId(),
                 transactionDto.Quantity,
                 (TransactionType)transactionDto.TransactionType);
 

--- a/Application/UseCases/DebitUseCase.cs
+++ b/Application/UseCases/DebitUseCase.cs
@@ -24,7 +24,7 @@ namespace Application.UseCases
             var asset = account.Assets.FirstOrDefault(a => a.AssetName == transactionDto.AssetName) ?? throw new EntityNotFoundException($"Asset {transactionDto.AssetName} not found"); ;
 
             var transaction = Transaction.Create(
-                asset.AssetId,
+                asset.GetId(),
                 transactionDto.Quantity,
                 (TransactionType)transactionDto.TransactionType);
 

--- a/DatabaseContext/Mappers/AssetMapper.cs
+++ b/DatabaseContext/Mappers/AssetMapper.cs
@@ -9,7 +9,7 @@ namespace DatabaseContext.Mappers
         {
             return new AssetModel
             {
-                AssetId = asset.AssetId,
+                AssetId = asset.GetId(),
                 AccountId = asset.AccountId,
                 AssetName = asset.AssetName,
                 Balance = asset.Balance,

--- a/Domain/Entities/Asset.cs
+++ b/Domain/Entities/Asset.cs
@@ -1,6 +1,7 @@
 ﻿using Domain.Enums;
 using Domain.Exceptions;
 using Domain.Validators;
+using Domain.ValueObjects;
 
 namespace Domain.Entities
 {
@@ -10,7 +11,8 @@ namespace Domain.Entities
         private static readonly AssetValidator _validator = new AssetValidator();
         private readonly List<Transaction> _transactions = [];
 
-        public Guid AssetId { get; set; }
+        private readonly ID _assetId;
+
         public Guid AccountId { get; set; }
         public string? AssetName { get; set; }
         public decimal Balance { get; private set; }
@@ -19,7 +21,7 @@ namespace Domain.Entities
 
         public Asset(Guid assetId, Guid accountId, string? assetName, List<Transaction> transactions)
         {
-            AssetId = assetId;
+            _assetId = new ID(assetId);
             AccountId = accountId;
             AssetName = assetName;
             Balance = 0;
@@ -31,6 +33,8 @@ namespace Domain.Entities
 
             Validate(this);
         }
+
+        public Guid GetId() => _assetId.GetValue();
 
         public static Asset Create(Guid accountId, string? assetName)
         {

--- a/Tests/Unit/Entities/AccountTests.cs
+++ b/Tests/Unit/Entities/AccountTests.cs
@@ -53,7 +53,7 @@ namespace Tests.Unit.Entities
                 "asdQWE123");
 
             var asset = Asset.Create(account.GetId(), "USD");
-            var transaction = Transaction.Create(asset.AssetId, 1000, TransactionType.Credit);
+            var transaction = Transaction.Create(asset.GetId(), 1000, TransactionType.Credit);
             asset.AddTransaction(transaction);
             account.AddAsset(asset);
 
@@ -80,7 +80,7 @@ namespace Tests.Unit.Entities
                 password: "asdQWE123");
 
             var asset = Asset.Create(account.GetId(), "USD");
-            var transaction = Transaction.Create(asset.AssetId, 10, TransactionType.Credit);
+            var transaction = Transaction.Create(asset.GetId(), 10, TransactionType.Credit);
             asset.AddTransaction(transaction);
             account.AddAsset(asset);
 

--- a/Tests/Unit/Entities/AssetTests.cs
+++ b/Tests/Unit/Entities/AssetTests.cs
@@ -60,7 +60,7 @@ namespace Tests.Unit.Entities
             // Arrange
             var accountId = Guid.NewGuid();
             var asset = Asset.Create(accountId, "BTC");
-            var deposit = Transaction.Create(asset.AssetId, 1.5m, TransactionType.Credit);
+            var deposit = Transaction.Create(asset.GetId(), 1.5m, TransactionType.Credit);
 
             // Act
             asset.AddTransaction(deposit);
@@ -77,8 +77,8 @@ namespace Tests.Unit.Entities
             // Arrange
             var accountId = Guid.NewGuid();
             var asset = Asset.Create(accountId, "BTC");
-            var deposit1 = Transaction.Create(asset.AssetId, 1.5m, TransactionType.Credit);
-            var deposit2 = Transaction.Create(asset.AssetId, 2.5m, TransactionType.Credit);
+            var deposit1 = Transaction.Create(asset.GetId(), 1.5m, TransactionType.Credit);
+            var deposit2 = Transaction.Create(asset.GetId(), 2.5m, TransactionType.Credit);
 
             // Act
             asset.AddTransaction(deposit1);

--- a/Tests/Unit/UseCase/PlaceOrderTests.cs
+++ b/Tests/Unit/UseCase/PlaceOrderTests.cs
@@ -65,7 +65,7 @@ namespace Tests.Unit.UseCase
                     password: "asdQWE123");
 
             var asset = Asset.Create(account.GetId(), "USD");
-            var transaction = Transaction.Create(asset.AssetId, placeOrderDto.Price, TransactionType.Credit);
+            var transaction = Transaction.Create(asset.GetId(), placeOrderDto.Price, TransactionType.Credit);
             asset.AddTransaction(transaction);
             account.AddAsset(asset);
             _accountRepositoryMock.Setup(repo => repo.GetAccountByAccountIdAsync(placeOrderDto.AccountId)).ReturnsAsync(account);


### PR DESCRIPTION
Substituído o acesso direto à propriedade `AssetId` pelo método `GetId()` em todo o sistema, refletindo a introdução do objeto de valor `ID` na classe `Asset`. A propriedade pública `AssetId` foi removida, melhorando a encapsulação e validação do identificador.

Principais mudanças:
- Introdução do objeto de valor `ID` em `Asset`.
- Atualização do método `Create` para inicializar `_assetId` com `ID`.
- Alterações em `CreditUseCase`, `DebitUseCase` e `AssetMapper`.
- Ajustes em testes unitários para refletir a nova abordagem.
- Importação de `Domain.ValueObjects` na classe `Asset`.
- Remoção de redundâncias e maior consistência no uso de identificadores.